### PR TITLE
[feat] Implement full window window edition on image carousel

### DIFF
--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -75,9 +75,46 @@ export default Vue.extend({
       <br />
       <SimplecomponentsVueImageCarousel
         :images="images"
-        :auto="false"
+        :auto="true"
         :ratio="'2:1'"
       >
+        <div
+          v-for="(image, imageIndex) in images"
+          :key="imageIndex"
+          :slot="'content-' + image.key"
+          @click="printAlert('image with key: ' + image.key)"
+          class="simple-test-container"
+        >
+          <div>
+            <h3>Image with key {{ image.key }}</h3>
+            <p>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Nulla,
+              magnam voluptates natus maiores doloremque ea pariatur id.
+              Reprehenderit atque blanditiis veritatis eos iste aut laboriosam
+              aspernatur dicta dolores, doloremque deserunt.
+            </p>
+          </div>
+        </div>
+      </SimplecomponentsVueImageCarousel>
+      <br />
+      <SimplecomponentsVueImageCarousel :images="images">
+        <div
+          v-for="(image, imageIndex) in images"
+          :key="imageIndex"
+          :slot="'content-shadow-' + image.key"
+          @click="printAlert('image with key: ' + image.key)"
+          class="simple-test-container"
+        >
+          <div>
+            <h3>Image with key {{ image.key }}</h3>
+            <p>
+              Lorem ipsum dolor sit amet consectetur adipisicing elit. Nulla,
+              magnam voluptates natus maiores doloremque ea pariatur id.
+              Reprehenderit atque blanditiis veritatis eos iste aut laboriosam
+              aspernatur dicta dolores, doloremque deserunt.
+            </p>
+          </div>
+        </div>
       </SimplecomponentsVueImageCarousel>
     </div>
   </div>
@@ -92,6 +129,14 @@ export default Vue.extend({
   align-items: center;
   padding-top: 40em;
   padding-bottom: 40em;
+}
+
+.simple-test-container {
+  height: 100%;
+  padding-left: 30px;
+  padding-top: 30px;
+  padding-right: 30px;
+  padding-bottom: 20px;
 }
 
 .simple-container-son {

--- a/src/lib-components/images/simplecomponents-vue-image-carousel/simplecomponents-vue-image-carousel.scss
+++ b/src/lib-components/images/simplecomponents-vue-image-carousel/simplecomponents-vue-image-carousel.scss
@@ -57,7 +57,8 @@
         border-bottom-left-radius: 4px;
       }
       .simple-background-arrow {
-        width: 10%;
+        z-index: 2;
+        width: 6%;
         background-color: rgba($color: #000000, $alpha: 0.5);
         cursor: pointer;
         display: flex;
@@ -71,7 +72,6 @@
           width: 100%;
           cursor: pointer;
           display: flex;
-          background-color: red;
           justify-content: center;
           align-items: center;
           padding: 0.5em;
@@ -90,25 +90,48 @@
     .simple-background-tag {
       width: 100%;
       display: flex;
+      cursor: pointer;
       justify-content: center;
-      align-items: center;
-      height: 15%;
+      align-items: flex-end;
+      z-index: 1;
+      height: 100%;
       position: absolute;
       color: white;
-      padding-top: 0.5em;
-      padding-bottom: 0.5em;
       font-size: 0.85em;
       bottom: 0;
+      * {
+        z-index: 1;
+      }
+    }
+
+    .simple-background-shadow {
+      width: 100%;
+      cursor: pointer;
+      display: flex;
+      justify-content: center;
+      align-items: flex-end;
+      // height: 15%;
+      z-index: 1;
+      position: absolute;
+      color: white;
+      font-size: 0.85em;
+      bottom: 0;
+      * {
+        z-index: 1;
+      }
       background: linear-gradient(
         0deg,
         rgba(0, 0, 0, 1) 0%,
-        rgba(0, 0, 0, 0.7189250700280112) 36%,
-        rgba(0, 0, 0, 0.5144432773109244) 65%,
+        rgba(0, 0, 0, 0.8) 10%,
+        rgba(0, 0, 0, 0.7) 20%,
+        rgba(0, 0, 0, 0.6) 30%,
+        rgba(0, 0, 0, 0.5) 45%,
+        rgba(0, 0, 0, 0.4) 55%,
+        rgba(0, 0, 0, 0.3) 65%,
+        rgba(0, 0, 0, 0.2) 80%,
+        rgba(0, 0, 0, 0.1) 90%,
         rgba(0, 0, 0, 0) 100%
       );
-      .simple-background-label {
-        margin-right: 0.35em;
-      }
     }
   }
 }

--- a/src/lib-components/images/simplecomponents-vue-image-carousel/simplecomponents-vue-image-carousel.vue
+++ b/src/lib-components/images/simplecomponents-vue-image-carousel/simplecomponents-vue-image-carousel.vue
@@ -36,8 +36,13 @@
             </div>
             <div v-else></div>
           </div>
-          <div v-if="$slots.default" class="simple-background-tag">
-            <slot></slot>
+          <div v-for="(file, fileIndex) in files" :key="fileIndex">
+            <div v-if="fileIndex == pointer" class="simple-background-tag">
+              <slot :name="'content-' + file.key"></slot>
+            </div>
+            <div v-if="fileIndex == pointer" class="simple-background-shadow">
+              <slot :name="'content-shadow-' + file.key"></slot>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
* Create a slot named content-shadow-[image key] for only a shadow at the
bottom
* Create a slot named content-[image key] for a full window child on
component
* Closes #6 